### PR TITLE
网易云扫码登陆时“消息过于频繁”；网易云扫码登录更方便的方法

### DIFF
--- a/DecryptLogin/modules/core/music163.py
+++ b/DecryptLogin/modules/core/music163.py
@@ -195,7 +195,7 @@ class music163Scanqr():
         #img.save(os.path.join(self.cur_path, 'qrcode.jpg'))
         #showImage(os.path.join(self.cur_path, 'qrcode.jpg'))
 
-        qr.print_ascii(out=None, tty=False, invert=False)
+        qr.print_ascii(out=None, tty=False, invert=False) # 使用print_ascii函数在终端打印二维码，实现github action 扫码
         # 检测二维码状态
         data = {
             'csrf_token': '',


### PR DESCRIPTION
1. 网易云扫描二维码登录时循环不到sleep函数，导致会在一定时间内不断请求，网易云接收请求太频繁会罢工qwq

2. 使用qrcode的print_ascii函数，直接在终端中打印二维码，方便使用github action